### PR TITLE
fix: Resolve server startup and database initialization errors

### DIFF
--- a/src/mcp_manual_walker/main.py
+++ b/src/mcp_manual_walker/main.py
@@ -2,7 +2,6 @@ import logging
 from contextlib import asynccontextmanager
 from pathlib import Path
 
-import uvicorn
 from fastmcp import FastMCP
 from markitdown import MarkItDown
 from sqlalchemy.orm import Session, joinedload
@@ -107,10 +106,14 @@ def sync_database():
 @asynccontextmanager
 async def lifespan(app: FastMCP):
     """Server startup event handler."""
-    logger.info("Initializing database...")
-    init_db()
+    logger.info("Initializing application...")
+    # Ensure all necessary directories exist before initializing the database
+    settings.DB_FILE_PATH.parent.mkdir(parents=True, exist_ok=True)
     settings.PDF_ROOT_DIR.mkdir(parents=True, exist_ok=True)
     settings.CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+    logger.info("Initializing database...")
+    init_db()
     sync_database()
     yield
 
@@ -221,4 +224,4 @@ def get_markdown_content(file_name: str, bookmark_title: str) -> str:
 
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    app.run(transport="http", host="0.0.0.0", port=8000)


### PR DESCRIPTION
This commit addresses a series of cascading errors that prevented the application from starting and running correctly.

The initial problem was an `AttributeError: 'FastMCP' object has no attribute 'on_event'`, caused by a deprecated startup decorator.

The fix for this involved two key changes based on `FastMCP`-specific patterns:
1.  Replaced the `@app.on_event("startup")` decorator with the modern `lifespan` async context manager, passed to the `FastMCP` constructor.
2.  Switched from running the server with `uvicorn.run()` to the framework's native `app.run(transport="http", ...)` method.

This resolved the startup errors but revealed a latent database issue: an `sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) unable to open database file` would occur on the first request.

This was because the parent directory for the SQLite database file (`./data/`) was not being created before the database connection was attempted.

The final fix adds a line to the `lifespan` startup event to explicitly create the database's parent directory, ensuring `init_db()` can execute successfully.

The application is now fully functional and stable on startup.